### PR TITLE
Add blog functionality with homepage and blog-detail page

### DIFF
--- a/app/blog/[id].tsx
+++ b/app/blog/[id].tsx
@@ -1,0 +1,50 @@
+import { useRouter } from 'next/router';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+
+const BlogDetail = () => {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const posts = [
+    {
+      id: 1,
+      title: 'First Post',
+      project: 'Project 1',
+      content: 'This is the content of the first post.'
+    },
+    {
+      id: 2,
+      title: 'Second Post',
+      project: 'Project 2',
+      content: 'This is the content of the second post.'
+    },
+    {
+      id: 3,
+      title: 'Third Post',
+      project: 'Project 3',
+      content: 'This is the content of the third post.'
+    }
+  ];
+
+  const post = posts.find((post) => post.id === parseInt(id as string));
+
+  if (!post) {
+    return <p>Post not found</p>;
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>{post.title}</CardTitle>
+          <CardDescription>{post.project}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p>{post.content}</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default BlogDetail;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,35 +2,29 @@
 import { useState } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
-import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Textarea } from '@/components/ui/textarea';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 
 export default function Home() {
-  const [open, setOpen] = useState(false);
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const [selectedProject, setSelectedProject] = useState('');
-
-  const projects = ['Project 1', 'Project 2', 'Project 3']; // Replace with your actual projects
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    // Handle form submission logic here
-    console.log('Title:', title);
-    console.log('Content:', content);
-    console.log('Selected Project:', selectedProject);
-    // Reset form fields
-    setTitle('');
-    setContent('');
-    setSelectedProject('');
-    setOpen(false);
-  };
+  const posts = [
+    {
+      id: 1,
+      title: 'First Post',
+      project: 'Project 1',
+      content: 'This is the content of the first post.'
+    },
+    {
+      id: 2,
+      title: 'Second Post',
+      project: 'Project 2',
+      content: 'This is the content of the second post.'
+    },
+    {
+      id: 3,
+      title: 'Third Post',
+      project: 'Project 3',
+      content: 'This is the content of the third post.'
+    }
+  ];
 
   return (
     <div className="container mx-auto p-4">
@@ -43,68 +37,21 @@ export default function Home() {
         <h1 className="text-4xl font-bold">DevLog</h1>
       </header>
 
-      <main className="flex justify-center">
-        <Dialog open={open} onOpenChange={setOpen}>
-          <DialogTrigger asChild>
-            <Button className="px-8 py-4 text-2xl">Post</Button>
-          </DialogTrigger>
-          <DialogContent className="sm:max-w-[850px]">
-            <DialogHeader>
-              <DialogTitle>Create Post</DialogTitle>
-            </DialogHeader>
-            <form onSubmit={handleSubmit}>
-              <div className="space-y-4 py-4">
-                <div>
-                  <Label htmlFor="title">Title</Label>
-                  <Input
-                    id="title"
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
-                    className="w-full"
-                    placeholder="Enter a title for your post"
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="project">Project</Label>
-                  <Select value={selectedProject} onValueChange={setSelectedProject}>
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Select a project" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {projects.map((project) => (
-                        <SelectItem key={project} value={project}>
-                          {project}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label htmlFor="content">Content</Label>
-                    <Textarea
-                      id="content"
-                      placeholder="Write your post in Markdown..."
-                      className="w-full resize-none"
-                      rows={10}
-                      value={content}
-                      onChange={(e) => setContent(e.target.value)}
-                    />
-                  </div>
-                  <div className="border border-gray-300 rounded-md p-2 overflow-auto prose">
-                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
-                  </div>
-                </div>
-              </div>
-              <div className="flex justify-end">
-                <Button type="submit">Post</Button>
-              </div>
-            </form>
-          </DialogContent>
-        </Dialog>
+      <main className="flex flex-col space-y-4">
+        {posts.map((post) => (
+          <Link key={post.id} href={`/blog/${post.id}`}>
+            <Card>
+              <CardHeader>
+                <CardTitle>{post.title}</CardTitle>
+                <CardDescription>{post.project}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p>{post.content}</p>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
       </main>
-
-     
     </div>
   );
 }


### PR DESCRIPTION
Add homepage and blog-detail page with dummy data and pleasing UI.

* **Homepage**: 
  - Import `Card`, `CardHeader`, `CardTitle`, `CardDescription`, and `CardContent` from `components/ui/card`.
  - Add dummy data for blog posts with title, project, and content.
  - Map over the dummy data to display each blog post in a `Card` component.
  - Add `Link` to each `Card` to navigate to the blog-detail page.
  - Remove the existing form and dialog code.

* **Blog-detail page**:
  - Create a new file `app/blog/[id].tsx`.
  - Import `Card`, `CardHeader`, `CardTitle`, `CardDescription`, and `CardContent` from `components/ui/card`.
  - Import `useRouter` from `next/router` to get the blog post id from the URL.
  - Add dummy data for blog posts with title, project, and content.
  - Find the blog post by id from the dummy data.
  - Display the blog post in a `Card` component with full content.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GhostScientist/devlog/pull/1?shareId=711bac5b-ae8a-4fb9-b23a-c2319c8011ba).